### PR TITLE
 feat: add VAPI assistant ID configuration support

### DIFF
--- a/insight-intelligence-corp/index.js
+++ b/insight-intelligence-corp/index.js
@@ -127,6 +127,8 @@ async function startVAPICall(twilioData) {
     const VAPI_API_KEY = process.env.VAPI_API_KEY;
     const VAPI_ENDPOINT = process.env.VAPI_ENDPOINT;
     
+    const VAPI_ASSISTANT_ID = process.env.VAPI_ASSISTANT_ID;
+    
     const vapiPayload = {
         type: 'inboundPhoneCall',
         phoneNumber: To,
@@ -134,8 +136,12 @@ async function startVAPICall(twilioData) {
             number: From
         },
         twilioCallSid: CallSid,
-        assistantId: process.env.VAPI_ASSISTANT_ID, // Optional: specify assistant
     };
+    
+    // Only include assistantId if it's configured
+    if (VAPI_ASSISTANT_ID) {
+        vapiPayload.assistantId = VAPI_ASSISTANT_ID;
+    }
     
     const response = await axios.post(`${VAPI_ENDPOINT}/call/phone`, vapiPayload, {
         headers: {

--- a/insight-intelligence-corp/main.tf
+++ b/insight-intelligence-corp/main.tf
@@ -42,6 +42,7 @@ module "twilio_vapi_webhook" {
   lambda_zip_path     = data.archive_file.lambda_zip.output_path
   vapi_api_key        = var.vapi_api_key
   vapi_endpoint       = var.vapi_endpoint
+  vapi_assistant_id   = var.vapi_assistant_id
   twilio_auth_token   = var.twilio_auth_token
 
   tags = var.tags

--- a/insight-intelligence-corp/terraform.tfvars.example
+++ b/insight-intelligence-corp/terraform.tfvars.example
@@ -1,12 +1,13 @@
 # Copy this file to terraform.tfvars and fill in your values
 
-aws_region = "us-east-1"
+aws_region = "us-west-2"
 project_name = "insight-intelligence-corp"
 environment = "dev"
 
 # Get these from your VAPI dashboard
 vapi_api_key = "your-vapi-api-key-here"
 vapi_endpoint = "https://api.vapi.ai"
+vapi_assistant_id = "your-vapi-assistant-id-here"
 
 # Get this from your Twilio console
 twilio_auth_token = "your-twilio-auth-token-here"

--- a/insight-intelligence-corp/variables.tf
+++ b/insight-intelligence-corp/variables.tf
@@ -34,6 +34,12 @@ variable "twilio_auth_token" {
   sensitive   = true
 }
 
+variable "vapi_assistant_id" {
+  description = "VAPI assistant ID to use for calls"
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)

--- a/terraform/modules/twilio-vapi-webhook/main.tf
+++ b/terraform/modules/twilio-vapi-webhook/main.tf
@@ -37,8 +37,9 @@ resource "aws_lambda_function" "webhook" {
 
   environment {
     variables = {
-      VAPI_API_KEY    = var.vapi_api_key
-      VAPI_ENDPOINT   = var.vapi_endpoint
+      VAPI_API_KEY      = var.vapi_api_key
+      VAPI_ENDPOINT     = var.vapi_endpoint
+      VAPI_ASSISTANT_ID = var.vapi_assistant_id
       TWILIO_AUTH_TOKEN = var.twilio_auth_token
     }
   }

--- a/terraform/modules/twilio-vapi-webhook/variables.tf
+++ b/terraform/modules/twilio-vapi-webhook/variables.tf
@@ -33,6 +33,12 @@ variable "vapi_endpoint" {
   default     = "https://api.vapi.ai"
 }
 
+variable "vapi_assistant_id" {
+  description = "VAPI assistant ID to use for calls"
+  type        = string
+  default     = ""
+}
+
 variable "twilio_auth_token" {
   description = "Twilio auth token for webhook validation"
   type        = string


### PR DESCRIPTION
  - Add vapi_assistant_id variable to Terraform configuration
  - Update Lambda environment to include VAPI_ASSISTANT_ID
  - Modify webhook handler to conditionally include assistantId in VAPI calls
  - Add assistant ID to terraform.tfvars.example with documentation
  - Ensure backward compatibility when assistant ID is not configured